### PR TITLE
Fix puppet syntax error

### DIFF
--- a/manifests/plugins/mongodb.pp
+++ b/manifests/plugins/mongodb.pp
@@ -10,7 +10,7 @@ class configure_collectd_plugins::plugins::mongodb (
 ) {
 
   if $::osfamily == 'RedHat' {
-    Exec { 'install epel-release':
+    Exec['install epel-release'] {
       command => 'yum install -y epel-release',
       before  => Package['python-pip']
     }


### PR DESCRIPTION
Our jenkins build running `puppet parser validate` (with puppet version 3.6.2) failed with

```
Error: Could not parse for environment production: Syntax error at 'install epel-release'; expected '}' at (...)/modules/signalfx_configure_collectd_plugins/manifests/plugins/mongodb.pp:13
```

See http://docs.puppetlabs.com/puppet/3/reference/lang_resources.html#amending-attributes-with-a-reference
